### PR TITLE
Added support for raw/command forwarding

### DIFF
--- a/config.py.example
+++ b/config.py.example
@@ -8,6 +8,7 @@ config = {
         'blacklist' : [
             '[Olaf]',
         ],
+        tgcmdprefix : '.tg_'
     },
 
     'telegram': {
@@ -16,6 +17,7 @@ config = {
         'blacklist': [
             'PollBot',
         ],
+        'allowraw': true
     },
 
     'bindings':(

--- a/teleirc.py
+++ b/teleirc.py
@@ -274,10 +274,10 @@ class MainBot(BotBase):
                 tel_target,
                 self.irc_tgcmdprefix != '' and msg.startswith(self.irc_tgcmdprefix) ?
                     msg.replace(self.irc_tgcmdprefix,'/',1) :
-                        self.msg_format.format(
-                            nick = irc_nick,
-                            msg = msg
-                        )
+                    self.msg_format.format(
+                        nick = irc_nick,
+                        msg = msg
+                    )
                 )
 
     @_handler

--- a/teleirc.py
+++ b/teleirc.py
@@ -272,12 +272,11 @@ class MainBot(BotBase):
         if tel_target is not None and irc_nick not in self.irc_blacklist:
             self.tel_connection.send_msg(
                 tel_target,
-                self.irc_tgcmdprefix != '' and msg.startswith(self.irc_tgcmdprefix) ?
-                    msg.replace(self.irc_tgcmdprefix,'/',1) :
-                    self.msg_format.format(
+                msg.replace(self.irc_tgcmdprefix,'/',1) if \
+                (self.irc_tgcmdprefix != '' and msg.startswith(self.irc_tgcmdprefix)) else \
+                self.msg_format.format(
                         nick = irc_nick,
                         msg = msg
-                    )
                 )
 
     @_handler


### PR DESCRIPTION
They are implemented as a `/raw` pseudo-command in tg side and a configurable prefix `.tg_` to replace telegram's `/` prefix at IRC side.

Syntax checks needed since I am too lazy to learn py or to check it.
